### PR TITLE
Only render errors if there are errors in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ const RegistrationForm = configureForm({
 	},
 })(({ form }) => (
 	<form.Form>
-		{!form.hasErrors &&
+		{form.hasErrors &&
 			<div>
 				<p style={{ color: 'red' }}>Please correct the your input</p>
 			</div>


### PR DESCRIPTION
The readme example showed rendering an error div when there are no errors with the form. This felt wrong to me so I thought I'd fix it up.