### PR TITLE
Added File input support.

### DIFF
--- a/src/example/FileInputForm.js
+++ b/src/example/FileInputForm.js
@@ -1,0 +1,112 @@
+// @flow
+import React from "react";
+import PropTypes from "prop-types";
+import { configureForm } from "../index";
+
+const withForm = configureForm({
+	initFields: () => ({ name: "", cv: null }),
+	validate,
+	submit: data => {
+		// Note, with File inputs you usually want to upload your data back
+		// to your server encoded as a multipart/form-data encoded payload.
+		// You can do this with the FormData API.
+		// Here's an example of how this would look
+		//
+		// const formData = new FormData();
+
+		// for (const key of Object.keys(data)) {
+		// 	formData.append(key, formData[key]);
+		// }
+
+		// fetch('/some-url', {
+		// 	method: 'POST',
+		// 	body: formData
+		// })
+		// .then(response => response.json())
+		// .catch(error => console.error('Error:', error))
+		// .then(response => console.log('Success:', response));
+
+		return new Promise(resolve => {
+			console.log("Sending data", data); // eslint-disable-line no-console
+			setTimeout(() => {
+				resolve({ success: true });
+			}, 1000);
+		});
+	},
+	onChange: (formData, props) => {
+		props.onFormStateChange(formData);
+	}
+});
+
+const FileInputForm = ({ form }) => (
+	<form.Form>
+		{form.hasErrors && (
+			<div
+				style={{
+					background: "#ff8787",
+					border: "2px solid #d21111",
+					color: "#8a0808",
+					padding: "1em",
+					marginBottom: 10
+				}}
+			>
+				{Object.keys(form.errors).map(key => (
+					<div key={key}>
+						<strong>{key}:</strong> {form.errors[key]}
+					</div>
+				))}
+			</div>
+		)}
+
+		<div style={{ marginBottom: 10 }}>
+			<label htmlFor="name">Name</label>
+			<input
+				id="name"
+				placeholder="eg. Borico Jones"
+				{...form.getInputProps({ name: "name" })}
+			/>
+		</div>
+		<div style={{ marginBottom: 10 }}>
+			<label htmlFor="cv">Select a file</label>
+			<label>
+				<input
+					{...form.getInputProps({
+						name: "cv",
+						type: "file"
+					})}
+				/>
+			</label>
+		</div>
+		<button type="submit" disabled={form.isLoading || form.hasErrors}>
+			Submit
+		</button>
+		<button type="reset" disabled={form.isLoading || form.hasErrors}>
+			Reset
+		</button>
+	</form.Form>
+);
+
+FileInputForm.propTypes = {
+	form: PropTypes.shape({
+		actions: PropTypes.objectOf(PropTypes.func),
+		fields: PropTypes.object,
+		state: PropTypes.object,
+		getInputProps: PropTypes.func
+	})
+};
+
+function validate(data) {
+	const errors = {};
+
+	if (!data.name) {
+		errors.name = "We must have a name";
+	}
+
+	if (!data.cv) {
+		errors.cv = "Please select a file";
+	}
+
+	return errors;
+}
+
+export default withForm(FileInputForm);

--- a/src/example/index.js
+++ b/src/example/index.js
@@ -6,11 +6,13 @@ import styled, { injectGlobal } from 'styled-components';
 import JsonView from 'react-json-view'
 
 import BasicWebForm from './BasicWebForm';
+import FileInputForm from "./FileInputForm";
 import CustomComponents from './CustomComponents';
 import MyVehicles from './MyVehicles';
 
 const forms = [
 	{ component: BasicWebForm, label: 'Basic Form' },
+	{ component: FileInputForm, label: "File Input Form" },
 	{ component: CustomComponents, label: 'Custom Form Fields' },
 	{ component: MyVehicles, label: 'Nested form' },
 ];
@@ -72,6 +74,22 @@ class App extends Component<any, State> {
 
 	render () {
 		const CurrentForm = forms[this.state.selectedForm];
+
+		// File objects don't get serialised nicely into JSON but we need
+		// to keep them in state so people can work with them.
+		// Go through our state and if anything is a file, replace it with
+		// a description of the file first.
+		//
+		// Make a copy so we don't mutate our state.
+		const formState = Object.assign({}, this.state.formState);
+
+		// Now clean it up ready to go.
+		for (const key of Object.keys(formState)) {
+			if (formState[key] instanceof File) {
+				formState[key] = `File: ${formState[key].name}`;
+			}
+		}
+
 		return (
 			<Main>
 				<Buttons
@@ -84,7 +102,7 @@ class App extends Component<any, State> {
 					onFormStateChange={this._handleFormStateChange}
 				/>
 				<h3>Form state</h3>
-				<JsonView src={this.state.formState} />
+				<JsonView src={formState} />
 			</Main>
 		);
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -208,7 +208,11 @@ export function configureForm ({
 			}
 
 			_createInputOnChange = (name: string, options: ChangeOptions) => (event: any) => {
-				this.updateField(name, event.currentTarget.value, options);
+				if (event.currentTarget.files) {
+					this.updateField(name, event.currentTarget.files[0], options);
+				} else {
+					this.updateField(name, event.currentTarget.value, options);
+				}
 			};
 
 			_createCheckOnChange = (name: string, options: ChangeOptions) => (event: any) => {
@@ -247,6 +251,11 @@ export function configureForm ({
 							value,
 							disabled,
 						});
+					case 'file':
+						return Object.assign(this.fieldProps[name], {
+							files: [this._getFieldValueWithDefault(name, value)],
+							disabled,
+						})
 					default:
 						return Object.assign(this.fieldProps[name], {
 							value: this._getFieldValueWithDefault(name, value),

--- a/tests/formInputProps.test.js
+++ b/tests/formInputProps.test.js
@@ -75,7 +75,7 @@ describe('formInputProps', () => {
 			{
 				name: 'cv',
 				type: 'file',
-				value: null,
+				files: [null],
 				disabled: false,
 				onChange: expect.any(Function),
 			},

--- a/tests/formInputProps.test.js
+++ b/tests/formInputProps.test.js
@@ -63,4 +63,23 @@ describe('formInputProps', () => {
 			{},
 		);
 	});
+	it('should provide props for a file input', () => {
+		const withForm = configureForm({ initFields: () => ({ cv: null }) });
+		const MockInput = jest.fn().mockReturnValue(<div />);
+		const Comp = withForm(({ form }) => (
+			<MockInput {...form.getInputProps({ type: 'file', name: 'cv', value: null })} />
+		));
+
+		mount(<Comp />);
+		expect(MockInput).toBeCalledWith(
+			{
+				name: 'cv',
+				type: 'file',
+				value: null,
+				disabled: false,
+				onChange: expect.any(Function),
+			},
+			{},
+		);
+	});
 });


### PR DESCRIPTION
First off, thanks for this library! It's awesome sauce.

We needed to be able to manage file inputs with this library. The main difference to a file input is the value you need in state is an actual File object, which can be obtained from the event with `event.target.files[0]`.

This seems to work on the example, but I'm not sure I did the absolutely best thing I could, so if any changes are needed or I can do more tests just let me know, happy to help!