### PR TITLE
Respository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@thinkmill/pragmatic-forms",
   "version": "1.3.0",
   "description": "A pragmatic approach to form handling in React",
+  "repository" : {
+    "type" : "git",
+    "url" : "https://github.com/Thinkmill/pragmatic-forms.git"
+  },
   "main": "lib/index.js",
   "scripts": {
     "start": "webpack-dev-server --config webpack.config.js",


### PR DESCRIPTION
I noticed that package.json didn't have a repository URL which means when people see the package on NPM they don't know where the code is coming from. I added the repo to the `package.json` file so they'll more easily be able to contribute to the library.